### PR TITLE
cmake: fix compatibility with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 project(OB-UDPST)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.10)
 if(${CMAKE_VERSION} VERSION_GREATER "3.3.0")
         cmake_policy(SET CMP0057 NEW)
 endif()


### PR DESCRIPTION
CMake 4 has dropped compatibility with old versions < 3.5, and will drop compatibility for < 3.10 in the future. Update the minimum required CMake version accordingly so that both old and new versions will work.